### PR TITLE
Fix building from the batch files in a VS 2022 local install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ sDNA/sdna_vs2008/sdna_vs2008.vcxproj.user
 output/**/*.dll
 output/**/*.py
 output/**/README.txt
-bin/*

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Backup
 Backup1
 .vs
 .vscode
+vcpkg_installed
+sDNA/sdna_vs2008/x64/Release
+output/release/x64/sdna_vs2008.dll
+sDNA/sdna_vs2008/sdna_vs2008.vcxproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ venv/
 *.sdf
 *.db
 UpgradeLog*.htm
-**/.vs/*
+*/.vs/*
 *.sln.cache
 Backup
 Backup1
@@ -14,5 +14,8 @@ Backup1
 .vscode
 vcpkg_installed
 sDNA/sdna_vs2008/x64/Release
-output/release/x64/sdna_vs2008.dll
 sDNA/sdna_vs2008/sdna_vs2008.vcxproj.user
+output/**/*.dll
+output/**/*.py
+output/**/README.txt
+bin/*

--- a/build_output.bat
+++ b/build_output.bat
@@ -1,5 +1,6 @@
 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall" amd64
 
-c:\windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe build_output.proj /t:rebuild /p:Configuration=release
+@REM c:\windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe build_output.proj /t:rebuild /p:Configuration=release
+"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /t:rebuild /p:Configuration=release
 
 pause

--- a/build_output_debug.bat
+++ b/build_output_debug.bat
@@ -1,5 +1,6 @@
 call vcvars64
 
-c:\windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe build_output.proj /t:rebuild /p:Configuration=debug /m
+@REM c:\windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe build_output.proj /t:rebuild /p:Configuration=debug /m
+"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" /t:rebuild /p:Configuration=debug /m
 
 pause

--- a/build_release.bat
+++ b/build_release.bat
@@ -1,5 +1,6 @@
 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
 
-c:\windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe build_installer.proj /t:rebuild /p:Configuration=release
+@REM c:\windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe build_installer.proj /t:rebuild /p:Configuration=release
+"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" build_installer.proj /t:rebuild /p:Configuration=release
 
 pause

--- a/download_geos_c.dll.bat
+++ b/download_geos_c.dll.bat
@@ -1,0 +1,15 @@
+@echo off
+
+set BUILD_DIR=%TMP%\sDNA_build_geos\geos
+REM Forward errors to nul in case BUILD_DIR already exists
+mkdir %BUILD_DIR% > nul 2> nul
+
+@echo on
+curl -L -o %BUILD_DIR%\geos_archive.tar.bz2 https://download.osgeo.org/osgeo4w/v2/x86_64/release/geos/geos-3.12.0-1.tar.bz2
+@echo off
+
+set CWD=%cd%
+cd %BUILD_DIR%
+tar -xf geos_archive.tar.bz2
+move bin\geos_c.dll %~dp0\output\release\x64
+cd %CWD%


### PR DESCRIPTION
Also adds batch files to download geos_c.dll from OSGEO4W, and package into .zip and tar.bz2 archives.