### PR TITLE
Replace R2u container with R2u action,

### DIFF
--- a/.github/actions/run_regression_tests/action.yml
+++ b/.github/actions/run_regression_tests/action.yml
@@ -58,46 +58,32 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # - uses: LizardByte/actions/actions/setup_python@master
-    #   with:
-    #     python-version: ${{ inputs.python_version }}
-    #     update-pyenv: 'false'
-
-    - name: Install uv
-      shell: bash
-      run: wget -qO- https://astral.sh/uv/install.sh | sh
-
-    - name: Install Python
-      shell: bash
-      run: |
-        . $HOME/.local/bin/env
-        uv python install ${{ inputs.python_version }}
-        uv venv ~/.venv
+    - uses: LizardByte/actions/actions/setup_python@master
+      with:
+        python-version: ${{ inputs.python_version }}
+        update-pyenv: 'false'
 
 
     # Windows only version specifier in R_full.txt
     - name: Install sDNA.
       if: ${{ inputs.sdna_installed_in_python_env }}
       shell: bash
-      run: |
-        . ~/.venv/bin/activate
-        uv pip install pytest dist/sdna_plus*.whl -r requirements/R_full.txt -r requirements/learn-predict.txt
-      
-        # pip
-        # install
-        # ${{ inputs.python_version == '3.5' && '--trusted-host pypi.python.org' || '' }}
-        # dist/sdna_plus*.whl
-        # -r requirements/R_full.txt
+      run: >
+        pip
+        install
+        ${{ inputs.python_version == '3.5' && '--trusted-host pypi.python.org' || '' }}
+        dist/sdna_plus*.whl
+        -r requirements/R_full.txt
 
     # All builds require PyTest and Numpy
-    # - name: Install Pytest, and Numpy (the latter for sDNA Learn & Predict, Python 3.5 only).
-    #   shell: bash
-    #   run: >
-    #     pip
-    #     install
-    #     ${{ inputs.python_version == '3.5' && '--trusted-host pypi.python.org' || ' ' }}
-    #     pytest
-    #     -r requirements/learn-predict.txt
+    - name: Install Pytest, and Numpy (the latter for sDNA Learn & Predict, Python 3.5 only).
+      shell: bash
+      run: >
+        pip
+        install
+        ${{ inputs.python_version == '3.5' && '--trusted-host pypi.python.org' || ' ' }}
+        pytest
+        -r requirements/learn-predict.txt
 
     # - name: Install sDNA.
     #   if: inputs.sdna_installed_in_python_env
@@ -109,7 +95,6 @@ runs:
       shell: ${{ inputs.shell }}
       working-directory: '${{ inputs.pytest_dir }}'
       run: |
-        . ~/.venv/bin/activate
         python --version
         python -c "import numpy; print(numpy.__version__)"
         python -m pytest --version
@@ -128,7 +113,7 @@ runs:
 
     - name: Run all the diff tests with Pytest.
       shell: ${{ inputs.shell }}
-      # working-directory: '${{ inputs.pytest_dir }}'
+      working-directory: ${{ inputs.pytest_dir }}
       env:
         DONT_TEST_N_LINK_SUBSYSTEMS_ORDER: ${{ inputs.DONT_TEST_N_LINK_SUBSYSTEMS_ORDER }}
         ALLOW_NEGATIVE_FORMULA_ERROR_ON_ANY_LINK_PRESENT: ${{ inputs.ALLOW_NEGATIVE_FORMULA_ERROR_ON_ANY_LINK_PRESENT }}
@@ -137,11 +122,7 @@ runs:
         sdna_bin_dir: ${{ inputs.sdna_bin_dir }}
         sdna_debug: ${{ inputs.sdna_debug }}
         USED_ZIG: ${{ inputs.USED_ZIG }}
-  
-      # run: pytest -rA --tb=short -c pyproject.toml .
-      run: |
-        . ~/.venv/bin/activate
-        pytest -rA --tb=short -c pyproject.toml ${{ inputs.pytest_dir }}
+      run: pytest -rA --tb=short
       # -rA shows summary of tests, one per line, even when they all pass.
       #
       # To run the same tests locally, the command is something like:

--- a/.github/workflows/build_installer_using_cmake_and_test.yml
+++ b/.github/workflows/build_installer_using_cmake_and_test.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       installer_file_name: ${{ steps.output_installer_file_name.outputs.name }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
 
 
@@ -109,7 +109,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Download installer built in previous job
       uses: actions/download-artifact@v6

--- a/.github/workflows/build_installer_using_msbuild_and_VS_and_test.yml
+++ b/.github/workflows/build_installer_using_msbuild_and_VS_and_test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ "main", "Cross_platform"]
+    branches: [ "main", "Cross_platform",]
 
   pull_request:
     branches: [ "main", "Cross_platform"]
@@ -22,7 +22,7 @@ jobs:
     outputs:
       installer_file_name: ${{ steps.output_installer_file_name.outputs.name }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
 
 
@@ -132,7 +132,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Download installer built in previous job
       uses: actions/download-artifact@v6

--- a/.github/workflows/build_linux_wheel_and_test.yml
+++ b/.github/workflows/build_linux_wheel_and_test.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ "Cross_platform", "Test_in_R_container",]
+    branches: [ "Cross_platform",]
 
   pull_request:
-    branches: [ "Cross_platform", "Test_in_R_container",]
+    branches: [ "Cross_platform",]
 
 jobs:
   build_linux_wheel:
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -55,14 +55,15 @@ jobs:
     name: "Run regression tests. "
     
     runs-on: ubuntu-latest
-    container:
-      image: rocker/r2u4ci:latest
 
 
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
+
+    - name: Setup r2u
+      uses: eddelbuettel/github-actions/r2u-setup@master
 
     - name: Install R deps
       run: Rscript -e "install.packages(c('optparse', 'sjstats', 'car', 'glmnet'))"
@@ -118,15 +119,15 @@ jobs:
     name: "Run smoke test. "
         
     runs-on: ubuntu-latest
-    container:
-      image: rocker/r2u4ci:latest
-
 
 
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
+
+    - name: Setup r2u
+      uses: eddelbuettel/github-actions/r2u-setup@master
 
     - name: Install R deps
       run: Rscript -e "install.packages(c('optparse', 'sjstats',  'car', 'glmnet'))"
@@ -139,14 +140,6 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python_version }}
-    # - uses: LizardByte/actions/actions/setup_python@master
-    #   with:
-    #     python-version: ${{ matrix.python_version }}
-    #     update-pyenv: false
-
-    # - name: Install numpy
-    #   shell: bash
-    #   run: python -m pip install -r requirements/base.txt -r requirements/learn-predict.txt
 
     - name: Download output tree built in previous job
       uses: actions/download-artifact@v6

--- a/.github/workflows/build_output_with_zig_and_test.yml
+++ b/.github/workflows/build_output_with_zig_and_test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ "main", "Cross_platform"]
+    branches: [ "main", "Cross_platform",]
 
   pull_request:
     branches: [ "main", "Cross_platform"]
@@ -22,7 +22,7 @@ jobs:
     name: Build output on Windows with Zig C++ (Ninja and CMake)
     runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
 
 
@@ -81,7 +81,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Download output tree built in previous job
       uses: actions/download-artifact@v6

--- a/.github/workflows/build_windows_wheel_and_test.yml
+++ b/.github/workflows/build_windows_wheel_and_test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ "Cross_platform"]
+    branches: [ "Cross_platform",]
 
   pull_request:
     branches: [ "Cross_platform"]
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install build deps
         shell: bash
@@ -49,7 +49,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
 
 
@@ -105,7 +105,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
 
 

--- a/.github/workflows/compile_so_with_gcc.yml
+++ b/.github/workflows/compile_so_with_gcc.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ "Cross_platform"]
+    branches: [ "Cross_platform",]
 
   pull_request:
     branches: [ "Cross_platform"]
@@ -23,7 +23,7 @@ jobs:
     # outputs:
     #   installer_file_name: ${{ steps.output_installer_file_name.outputs.name }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install Git and Ninja
       run: |
@@ -68,7 +68,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
 
     - name: Install R

--- a/.github/workflows/compile_so_with_zig.yml
+++ b/.github/workflows/compile_so_with_zig.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ "Cross_platform"]
+    branches: [ "Cross_platform",]
 
   pull_request:
     branches: [ "Cross_platform"]
@@ -24,7 +24,7 @@ jobs:
     # outputs:
     #   installer_file_name: ${{ steps.output_installer_file_name.outputs.name }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
 
 
@@ -79,7 +79,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install R
       run: |

--- a/.github/workflows/smoke_test_gcc.yml
+++ b/.github/workflows/smoke_test_gcc.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [ "Cross_platform", "Linux_and_PyPi", ]
+    branches: [ "Cross_platform", ]
 
   pull_request:
-    branches: [ "Cross_platform", "Linux_and_PyPi", ]
+    branches: [ "Cross_platform", ]
 
 env:
   CONFIGURATION: Release
@@ -22,7 +22,7 @@ jobs:
     # outputs:
     #   installer_file_name: ${{ steps.output_installer_file_name.outputs.name }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install Git
       run: |
@@ -84,7 +84,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
         # echo "new line of text" | sudo tee -a /etc/apt/sources.list
     - name: Install R and deps

--- a/.github/workflows/test_sDNA_release.yml
+++ b/.github/workflows/test_sDNA_release.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python_version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', ] # '2.7', '3.5', '3.6', '3.7',  ]
         
         # cannot install numpy on: ['3.13.0-alpha.4']
         # https://github.com/JamesParrott/sdna_plus/issues/14
@@ -40,7 +40,7 @@ jobs:
     steps:
 
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
 
     # - name: Download and install release of sDNA, then delete installer file.


### PR DESCRIPTION
Use setup UV action in containerised action & run on this branch

Insert v

Don't activate local env file (to get uv on path) when using setup uv action

Install Numpy

Don't activate the venv

Restore tests action

Replace R2u container with action,

and bump checkout to v6 from v5

Run smoke tests in runner, not in a containerised action

Run all on this branch